### PR TITLE
Support for * in the origin list for partial matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,29 @@ server.pre(cors.preflight);
 server.use(cors.actual);
 ```
 
+## Allowed origins
+
+As a convenience method, you can use the `*` character as a wildcard. This means you can allow any origins:
+
+```js
+origins: ['*']
+```
+
+Or you can also allow selected subdomains of your application:
+
+```js
+origins: [
+  'http://myapp.com',
+  'http://*.myapp.com'
+]
+```
+
+For added security, this middleware sets `Access-Control-Allow-Origin` to the origin that matched, not the configured wildcard.
+
+## Troubleshooting
+
+As per the spec, requests without an `Origin` will not receive any headers. Requests with a matching `Origin` will receive the appropriate response headers. Always be careful that any reverse proxies (e.g. Varnish) very their cache depending on the origin, so you don't serve CORS headers to the wrong request.
+
 ## Compliance to the spec
 
-See [unit tests](https://github.com/TabDigital/restify-cors-middleware/tree/master/test)
-for examples of preflight and actual requests.
+See [unit tests](https://github.com/TabDigital/restify-cors-middleware/tree/master/test) for examples of preflight and actual requests.

--- a/src/origin.js
+++ b/src/origin.js
@@ -1,10 +1,15 @@
 
-exports.match = function(origin, list) {
-  function belongs(o) {
-    return (origin === o || o === "*");
+exports.allowed = function(list, requestOrigin) {
+  function match(origin) {
+    if (origin.indexOf('*') !== -1) {
+      var regex = '^' + origin.replace('.', '\\.').replace('*', '.*') + '$';
+      return requestOrigin.match(regex);
+    } else {
+      return requestOrigin === origin;
+    }
   }
-  if (origin && list.some(belongs)) {
-    return origin;
+  if (requestOrigin) {
+    return list.some(match);
   } else {
     return false;
   }

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -22,7 +22,7 @@ exports.handler = function(options) {
 
     // 6.2.1 and 6.2.2
     originHeader = req.headers['origin'];
-    if (origin.match(originHeader, options.origins) === false) return next();
+    if (origin.allowed(options.origins || [], originHeader) === false) return next();
 
     // 6.2.3
     requestedMethod = req.headers['access-control-request-method'];

--- a/test/origin.spec.js
+++ b/test/origin.spec.js
@@ -3,29 +3,39 @@ var origin = require('../src/origin');
 
 describe('Origin list', function() {
 
-  var list = [
-    'http://api.myapp.com',
-    'http://www.myapp.com'
-  ];
-
-  it('returns null if the origin is not in the list', function() {
-    var o = origin.match('http://random-website.com', list);
-    o.should.eql(false);
+  it('returns false if the request has no origin', function() {
+    var list = ['http://api.myapp.com', 'http://www.myapp.com']
+    origin.allowed(list, null).should.eql(false);
   });
 
-  it('does not do partial matches', function() {
-    var o = origin.match('api.myapp.com', list);
-    o.should.eql(false);
+  it('returns false if the origin is not in the list', function() {
+    var list = ['http://api.myapp.com', 'http://www.myapp.com']
+    origin.allowed(list, 'http://random-website.com').should.eql(false);
   });
 
-  it('returns the origin if it matched', function() {
-    var o = origin.match('http://api.myapp.com', list);
-    o.should.eql('http://api.myapp.com');
+  it('returns true if the origin matched', function() {
+    var list = ['http://api.myapp.com', 'http://www.myapp.com']
+    origin.allowed(list, 'http://api.myapp.com').should.eql(true);
   });
 
-  it('returns the origin if the list contains *', function() {
-    var o = origin.match('http://random-website.com', ['*']);
-    o.should.eql('http://random-website.com');
+  it('does not do partial matches by default', function() {
+    var list = ['http://api.myapp.com', 'http://www.myapp.com']
+    origin.allowed(list, 'api.myapp.com').should.eql(false);
+  });
+
+  it('supports * for partial matches', function() {
+    var list = ['http://*.myapp.com', 'http://other-website.com']
+    origin.allowed(list, 'http://api.myapp.com').should.eql(true);
+  });
+
+  it('escapes the partial regex properly', function() {
+    var list = ['http://*.myapp.com', 'http://other-website.com']
+    origin.allowed(list, 'http://xmyapp.com').should.eql(false);
+  });
+
+  it('returns false if there was no partial match', function() {
+    var list = ['http://*.myapp.com']
+    origin.allowed(list, 'http://random-website.com').should.eql(false);
   });
 
 });


### PR DESCRIPTION
_From the README_

As a convenience method, you can use the `*` character as a wildcard. This means you can allow any origins:

``` js
origins: ['*']
```

Or you can also allow selected subdomains of your application:

``` js
origins: [
  'http://myapp.com',
  'http://*.myapp.com'
]
```

For added security, this middleware sets `Access-Control-Allow-Origin` to the origin that matched, not the configured wildcard.
