### PR TITLE
Add option to specify the preflight max age

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 var corsMiddleware = require('restify-cors-middleware');
 
 var cors = corsMiddleware({
+  preflightMaxAge: 5 //Optional
   origins: ['http://api.myapp.com', 'http://web.myapp.com'],
   allowHeaders: ['API-Token'],
   exposeHeaders: ['API-Token-Expiry']

--- a/src/preflight.js
+++ b/src/preflight.js
@@ -42,6 +42,11 @@ exports.handler = function(options) {
       res.header('Access-Control-Allow-Origin', originHeader);
       res.header('Access-Control-Allow-Credentials', true);
 
+      // 6.2.8
+      if (options.preflightMaxAge) {
+        res.header('Access-Control-Max-Age', options.preflightMaxAge);
+      }
+
       // 6.2.9
       res.header('Access-Control-Allow-Methods', allowedMethods.join(', '));
 
@@ -54,4 +59,3 @@ exports.handler = function(options) {
   };
 
 };
-

--- a/test/cors.preflight.spec.js
+++ b/test/cors.preflight.spec.js
@@ -84,8 +84,18 @@ describe('CORS: preflight requests', function() {
         .end(done);
     });
 
-    xit('6.2.8 Access-Control-Max-Age not supported', function(done) {
-      done();
+    it('6.2.8 Set the Access-Control-Max-Age header if a max age is provided', function(done) {
+      var server = test.corsServer({
+        preflightMaxAge: 5,
+        origins: ['http://api.myapp.com', 'http://www.myapp.com']
+      });
+      request(server)
+        .options('/test')
+        .set('Origin', 'http://api.myapp.com')
+        .set('Access-Control-Request-Method', 'GET')
+        .expect('Access-Control-Max-Age', '5')
+        .expect(204)
+        .end(done);
     });
 
     it('6.2.9 Set the Allow-Method header', function(done) {


### PR DESCRIPTION
@TabDigital/api 

Allows the browser to cache the `options` request for a specified amount of time
