### PR TITLE
allow regexp for origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ server.use(cors.actual)
 
 ## Allowed origins
 
-You can specify the full list of domains and subdomains allowed in your application:
+You can specify the full list of domains and subdomains allowed in your application, using strings or regular expressions.
 
 ```js
 origins: [
   'http://myapp.com',
-  'http://*.myapp.com'
+  'http://*.myapp.com',
+  /^https?:\/\/myapp.com(:[\d]+)?$/
 ]
 ```
 

--- a/src/origin-matcher.js
+++ b/src/origin-matcher.js
@@ -13,7 +13,9 @@ exports.create = function (allowedOrigins) {
 }
 
 function createMatcher (allowedOrigin) {
-  if (allowedOrigin.indexOf('*') === -1) {
+  if (allowedOrigin instanceof RegExp) {
+    return requestOrigin => requestOrigin.match(allowedOrigin)
+  } else if (allowedOrigin.indexOf('*') === -1) {
     // simple string comparison
     return requestOrigin => requestOrigin === allowedOrigin
   } else {

--- a/test/origin.spec.js
+++ b/test/origin.spec.js
@@ -52,4 +52,10 @@ describe('Origin list', function () {
     var matcher = originMatcher.create(list)
     matcher('http://random-website.com').should.eql(false)
   })
+
+  it('supports regular expressions', function () {
+    var list = ['http://api.myapp.com', /https?:\/\/example.com(:8888)?/]
+    var matcher = originMatcher.create(list)
+    matcher('https://example.com:8888').should.eql(true)
+  })
 })


### PR DESCRIPTION
.. there seems to be half-done support for this; we assert that origins is a list of either strings or regexps, but then passing a regexp will break things.  This PR fixes that, adds a test, and gives an example.