### PR TITLE
Send out less access-control-allow-headers

### DIFF
--- a/src/preflight.js
+++ b/src/preflight.js
@@ -19,8 +19,7 @@ exports.handler = function (options) {
     // requestedHeaders = requestedHeaders ? requestedHeaders.split(', ') : []
 
     var allowedMethods = [requestedMethod, 'OPTIONS']
-    var allowedHeaders = constants['ALLOW_HEADERS']
-                            .concat(options.allowHeaders)
+    var allowedHeaders = options.allowHeaders
 
     res.once('header', function () {
       // 6.2.7

--- a/test/cors.preflight.spec.js
+++ b/test/cors.preflight.spec.js
@@ -125,4 +125,24 @@ describe('CORS: preflight requests', function () {
         .expect(204)
         .end(done)
   })
+
+  it('[Not in spec] The Allow-Headers should not contain duplicates', function (done) {
+    var server = test.corsServer({
+      origins: ['http://api.myapp.com', 'http://www.myapp.com']
+    })
+    request(server)
+        .options('/test')
+        .set('Origin', 'http://api.myapp.com')
+        .set('Access-Control-Request-Method', 'GET')
+        .expect(204)
+        .then(function (request) {
+          var allowHeaders = request.headers['access-control-allow-headers'].split(', ')
+
+          if (((new Set(allowHeaders)).size !== allowHeaders.length)) {
+            return done(new Error('duplicate header detected'))
+          }
+
+          done(null)
+        })
+  })
 })


### PR DESCRIPTION
This pull requests fixes the issue where preflight requests received duplicate access-control-allow-headers.

The issue is fixed by only sending the `opts.allowHeaders` in the preflight handler, since user specified and preconfigured are already merged in https://github.com/TabDigital/restify-cors-middleware/blob/3d0f3257a6eb6f4ce0c9b0e2d14950899e109bd5/src/index.js#L67

Cheers!