### PR TITLE
Bump peer dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "require-lint && standard && mocha"
   },
   "peerDependencies": {
-    "restify": "2.6.x - 5.x.x"
+    "restify": "2.6.x - 6.x.x"
   },
   "devDependencies": {
     "mocha": "~3.4.1",


### PR DESCRIPTION
Resolves GH-36

Expands peer dependency version range for the `restify` module from `2.6.x - 5.x.x` to `2.6.x - 6.x.x` as to match the `6.0.0` release that was published on September 15th. 

This is obviously a short term fix. Finding a way to keep this module up-to-date with Restify is a larger issue likely worth discussing.