### PR TITLE
Fix link to W3C Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # restify-cors-middleware
 
-> CORS middleware with full [W3C spec](www.w3.org/TR/cors) support.
+> CORS middleware with full [W3C spec](https://www.w3.org/TR/cors/) support.
 
 [![NPM](http://img.shields.io/npm/v/restify-cors-middleware.svg?style=flat)](https://npmjs.org/package/restify-cors-middleware)
 [![License](http://img.shields.io/npm/l/restify-cors-middleware.svg?style=flat)](https://github.com/TabDigital/restify-cors-middleware)


### PR DESCRIPTION
Link is missing `https://`, so its relative to the `https://github.com/Tabcorp/restify-cors-middleware/blob/master` URL, thus making it unreachable.