### PR TITLE
chore(package): use >= range for restify peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "require-lint && standard && mocha"
   },
   "peerDependencies": {
-    "restify": "2.6.x - 5.x.x"
+    "restify": ">=2.6"
   },
   "devDependencies": {
     "mocha": "~3.4.1",


### PR DESCRIPTION
Hello,

thanks for this plugin.
As restify is already past version 6, and still compatible with this package I updated the peerDependency definition to include that.
To future proof this setting I used an opened ended >= range.

This gets rid of an npm warning

> npm WARN restify-cors-middleware@1.0.1 requires a peer of restify@2.6.x - 5.x.x but none is installed. You must install peer dependencies yourself.

Thanks for considering,

Stephan