### PR TITLE
 Updating restify peer dependency version range 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "require-lint && standard && mocha"
   },
   "peerDependencies": {
-    "restify": "2.6.x - 6.x.x"
+    "restify": "2.6.x - 7.x.x"
   },
   "devDependencies": {
     "mocha": "~3.4.1",


### PR DESCRIPTION
Should fix npm `restify-cors-middleware@1.1.0 requires a peer of restify@2.6.x - 6.x.x but none is installed` warning. 

Unsure if v7.x.x is supported currently but I am using it and am having no issues.