### PR TITLE
Patch 1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,9 +56,9 @@ module.exports = function (options) {
   opts.allowHeaders = options.allowHeaders || []
   opts.exposeHeaders = options.exposeHeaders || []
 
-  assert.ok(options.origins.indexOf('*') === -1 ||
-              options.credentials === false,
-              'credentials not supported with wildcard')
+  // assert.ok(options.origins.indexOf('*') === -1 ||
+  //             options.credentials === false,
+  //             'credentials not supported with wildcard')
 
   constants['EXPOSE_HEADERS'].forEach(function (h) {
     if (opts.exposeHeaders.indexOf(h) === -1) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ module.exports = function (options) {
     })
   }
   assert.optionalBool(options.credentials, 'options.credentials')
+  assert.optionalBool(options.allowCredentialsAllOrigins, 'options.allowCredentialsAllOrigins')
   assert.optionalArrayOfString(options.allowHeaders, 'options.allowHeaders')
   assert.optionalArrayOfString(options.exposeHeaders,
                                  'options.exposeHeaders')
@@ -57,7 +58,7 @@ module.exports = function (options) {
   opts.allowHeaders = options.allowHeaders || []
   opts.exposeHeaders = options.exposeHeaders || []
 
-  if (!allowCredentialsAllOrigins) {
+  if (!opts.allowCredentialsAllOrigins) {
     assert.ok(options.origins.indexOf('*') === -1 ||
                 options.credentials === false,
                 'credentials not supported with wildcard')

--- a/src/index.js
+++ b/src/index.js
@@ -53,12 +53,15 @@ module.exports = function (options) {
   var opts = options
   opts.origins = options.origins || ['*']
   opts.credentials = options.credentials || false
+  opts.allowCredentialsAllOrigins = options.allowCredentialsAllOrigins || false
   opts.allowHeaders = options.allowHeaders || []
   opts.exposeHeaders = options.exposeHeaders || []
 
-  // assert.ok(options.origins.indexOf('*') === -1 ||
-  //             options.credentials === false,
-  //             'credentials not supported with wildcard')
+  if (!allowCredentialsAllOrigins) {
+    assert.ok(options.origins.indexOf('*') === -1 ||
+                options.credentials === false,
+                'credentials not supported with wildcard')
+  }
 
   constants['EXPOSE_HEADERS'].forEach(function (h) {
     if (opts.exposeHeaders.indexOf(h) === -1) {


### PR DESCRIPTION
Override to allow `credentials: true` for `origin '*'`