### PR TITLE
Update restify peer-dependency (Restify 8.x.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "require-lint && standard && mocha"
   },
   "peerDependencies": {
-    "restify": "2.6.x - 7.x.x"
+    "restify": "2.6.x - 8.x.x"
   },
   "devDependencies": {
     "mocha": "~3.4.1",


### PR DESCRIPTION
`warning " > restify-cors-middleware@1.1.1" has incorrect peer dependency "restify@2.6.x - 7.x.x".
`
The module seems to work correctly, however it produces this warning when used with Restify 8. This pull request fix this.